### PR TITLE
Update SciChart to version 3

### DIFF
--- a/bench/bench_scichart.js
+++ b/bench/bench_scichart.js
@@ -4,13 +4,19 @@ const BENCHMARK_IMPLEMENTATION = (() => {
       const libScript = document.createElement("script");
 
       libScript.onload = () => {
-        SciChart.SciChartSurface.useWasmFromCDN();
+        SciChart.SciChartSurface.configure({
+          dataUrl:
+            "https://cdn.jsdelivr.net/npm/scichart@3.1.333/_wasm/scichart2d.data",
+          wasmUrl:
+            "https://cdn.jsdelivr.net/npm/scichart@3.1.333/_wasm/scichart2d.wasm",
+        });
         // debug scichart version
         console.log("SciChart version", SciChart.libraryVersion);
         resolve();
       };
 
-      libScript.src = "https://cdn.jsdelivr.net/npm/scichart@3/index.min.js"
+      libScript.src =
+        "https://cdn.jsdelivr.net/npm/scichart@3.1.333/index.min.js";
 
       document.body.append(libScript);
     });
@@ -38,11 +44,14 @@ const BENCHMARK_IMPLEMENTATION = (() => {
 
       SciChartDefaults.useNativeText = true;
 
-      const sciChart = await SciChartSurface.createSingle("chart", { theme: new SciChartJsNavyTheme() });
+      const sciChart = await SciChartSurface.createSingle("chart", {
+        theme: new SciChartJsNavyTheme(),
+      });
       sciChartSurface = sciChart.sciChartSurface;
       wasmContext = sciChart.wasmContext;
 
       xAxis = new NumericAxis(wasmContext);
+      xAxis.axisTitle = "time domain";
       if (BENCHMARK_CONFIG.mode !== "append") {
         xAxis.visibleRange = new NumberRange(
           0,
@@ -50,6 +59,7 @@ const BENCHMARK_IMPLEMENTATION = (() => {
         );
       }
       const yAxis = new NumericAxis(wasmContext);
+      yAxis.autoRange = EAutoRange.Always;
       sciChartSurface.xAxes.add(xAxis);
       sciChartSurface.yAxes.add(yAxis);
 
@@ -59,6 +69,15 @@ const BENCHMARK_IMPLEMENTATION = (() => {
       }
 
       sciChartSurface.chartModifiers.add(
+        new CursorModifier({
+          crosshairStroke: "red",
+          crosshairStrokeThickness: 1,
+          tooltipContainerBackground: "green",
+          tooltipTextStroke: "white",
+          showTooltip: true,
+          axisLabelFill: "green",
+          axisLabelStroke: "white",
+        }),
         new ZoomPanModifier(),
         new ZoomExtentsModifier(),
         new MouseWheelZoomModifier()
@@ -74,7 +93,7 @@ const BENCHMARK_IMPLEMENTATION = (() => {
           const nRendSeries = new FastLineRenderableSeries(wasmContext, {
             dataSeries: nDataSeries,
             strokeThickness: BENCHMARK_CONFIG.strokeThickness,
-            stroke: "auto"
+            stroke: "auto",
           });
           sciChartSurface.renderableSeries.add(nRendSeries);
           return {


### PR DESCRIPTION
Reviewed changes proposed here https://github.com/Arction/javascript-charts-performance-comparison/pull/3
Thanks for contributing!

This updates the benchmark app in the repository to use latest SciChart JS version.
**However,** updating the benchmarks and results will have to wait since it is a huuuge work. We also need to update 10+ other libraries, run all the tests with every single one of them and then update the results.

Reverted some changes:
- Use of `useWasmFromCDN`. This would make it harder to know what lib version was used in tests that were run before. In general I like explicitly selecting the version better.
- Re-added the cursor modifier. It shouldn't affect the test results since its not visible during tests, but I believe all charts part of the tests have cursor functionality enabled, so this one should also.
